### PR TITLE
Enable stateless mode for StreamableHTTPHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -358,7 +358,7 @@ func main() {
 
 		handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 			return srv
-		}, nil)
+		}, &mcp.StreamableHTTPOptions{Stateless: true})
 
 		fmt.Printf("Streamable HTTP Endpoint: http://localhost:%s/mcp\n", httpAddr)
 


### PR DESCRIPTION
Update `NewStreamableHTTPHandler` to pass `&mcp.StreamableHTTPOptions{Stateless: true}` to enable the stateless 2026-07-28 protocol over HTTP transport.